### PR TITLE
Use GFM Checkboxes

### DIFF
--- a/layout-checklist.md
+++ b/layout-checklist.md
@@ -2,104 +2,104 @@
 
 ## General
 
-* [Schematic review](schematic-checklist.md) complete and signed off, including pin swaps done during layout
-* Layout DRC 100% clean
+* [ ] [Schematic review](schematic-checklist.md) complete and signed off, including pin swaps done during layout
+* [ ] Layout DRC 100% clean
 
 ## Decoupling
 
-* Decoupling caps as close to power pins as possible
-* Low inductance mounting used for decoupling (prefer ViP if available, otherwise "[]8" shaped side vias
+* [ ] Decoupling caps as close to power pins as possible
+* [ ] Low inductance mounting used for decoupling (prefer ViP if available, otherwise "[]8" shaped side vias
 
 ## DFM / yield enhancement
 
-* All design rules within manufacturer's capability
-* Minimize use of vias/traces that push fab limits
-* Controlled impedance specified in fab notes if applicable
-* Stackup verified with manufacturer and specified in fab notes
-* Board finish specified in fab notes
-* If panelizing, add panel location indicators for identifying location-specific reflow issues
-* (recommended) Layer number markers specified to ensure correct assembly
-* Fiducials present (on both sides of board) if targeting automated assembly
-* Fiducial pattern asymmetric to detect rotated boards
-* Soldermask/copper clearance on fiducials respected
-* Panelization specified if required
+* [ ] All design rules within manufacturer's capability
+* [ ] Minimize use of vias/traces that push fab limits
+* [ ] Controlled impedance specified in fab notes if applicable
+* [ ] Stackup verified with manufacturer and specified in fab notes
+* [ ] Board finish specified in fab notes
+* [ ] If panelizing, add panel location indicators for identifying location-specific reflow issues
+* [ ] (recommended) Layer number markers specified to ensure correct assembly
+* [ ] Fiducials present (on both sides of board) if targeting automated assembly
+* [ ] Fiducial pattern asymmetric to detect rotated boards
+* [ ] Soldermask/copper clearance on fiducials respected
+* [ ] Panelization specified if required
 
 ## Footprints
 
-* Confirm components are available in the selected package
-* Verify schematic symbol matches the selected package
-* Confirm pinout diagram is from top vs bottom of package
-* (recommended) PCB printed 1:1 on paper and checked against physical parts
-* 3D models obtained (if available) and checked against footprints
-* Soldermask apertures on all SMT lands and PTH pads
+* [ ] Confirm components are available in the selected package
+* [ ] Verify schematic symbol matches the selected package
+* [ ] Confirm pinout diagram is from top vs bottom of package
+* [ ] (recommended) PCB printed 1:1 on paper and checked against physical parts
+* [ ] 3D models obtained (if available) and checked against footprints
+* [ ] Soldermask apertures on all SMT lands and PTH pads
 
 ## Differential pairs
-* Routed differentially
-* Skew matched
-* Correct clearance to non-coupled nets
+* [ ] Routed differentially
+* [ ] Skew matched
+* [ ] Correct clearance to non-coupled nets
 
 ## High-speed signals
 
-* Sufficient clearance to potential aggressors
-* Length matched if required
-* Minimize crossing reference plane splits/slots or changing layers, use caps/stitching vias if unavoidable
-* Confirm fab can do copper to edge of PCB for edge launch connectors
-* Double-check pad width on connectors and add plane cutouts if needed to minimize impedance discontinuities
+* [ ] Sufficient clearance to potential aggressors
+* [ ] Length matched if required
+* [ ] Minimize crossing reference plane splits/slots or changing layers, use caps/stitching vias if unavoidable
+* [ ] Confirm fab can do copper to edge of PCB for edge launch connectors
+* [ ] Double-check pad width on connectors and add plane cutouts if needed to minimize impedance discontinuities
 
 ## Power
-* Minimal slots in planes from via antipads
-* Sufficient width for planes/traces for required current
+* [ ] Minimal slots in planes from via antipads
+* [ ] Sufficient width for planes/traces for required current
 
 ## Sensitive analog
-* Guard ring / EMI cages provided if needed
-* Physically separated from high current SMPS or other noise sources
-* Consider microphone effect on MLCCs if near strong sound sources
+* [ ] Guard ring / EMI cages provided if needed
+* [ ] Physically separated from high current SMPS or other noise sources
+* [ ] Consider microphone effect on MLCCs if near strong sound sources
 
 ## Mechanical
-* LEDs, buttons, and other UI elements on outward-facing side of board
-* Keep-outs around PCB perimeter, card guides, panelization mouse-bites, etc respected
-* Stress-sensitive components (MLCC) sufficiently clear from V-score or mouse bite locations, and oriented to reduce
+* [ ] LEDs, buttons, and other UI elements on outward-facing side of board
+* [ ] Keep-outs around PCB perimeter, card guides, panelization mouse-bites, etc respected
+* [ ] Stress-sensitive components (MLCC) sufficiently clear from V-score or mouse bite locations, and oriented to reduce
 bending stress
-* Clearance around large ICs for heatsinks/fans if required
-* Clearance around pluggable connectors for mating cable/connector
-* Clearance around mounting holes for screws
-* Plane keepouts and clearance provided for shielded connectors, magnetics, etc
-* Confirm PCB dimensions and mounting hole size/placement against enclosure or card rack design
-* Verify mounting hole connection/isolation
-* Components not physically overlapping/colliding
-* Clearance provided around solder-in test points for probe tips
+* [ ] Clearance around large ICs for heatsinks/fans if required
+* [ ] Clearance around pluggable connectors for mating cable/connector
+* [ ] Clearance around mounting holes for screws
+* [ ] Plane keepouts and clearance provided for shielded connectors, magnetics, etc
+* [ ] Confirm PCB dimensions and mounting hole size/placement against enclosure or card rack design
+* [ ] Verify mounting hole connection/isolation
+* [ ] Components not physically overlapping/colliding
+* [ ] Clearance provided around solder-in test points for probe tips
 
 ## Thermal
 
-* Thermal reliefs used for plane connections (unless via is used for heatsinking)
-* Solid connections used to planes if heatsinking
-* Ensure thermal balance on SMT chip components to minimize risk of tombstoning
+* [ ] Thermal reliefs used for plane connections (unless via is used for heatsinking)
+* [ ] Solid connections used to planes if heatsinking
+* [ ] Ensure thermal balance on SMT chip components to minimize risk of tombstoning
 
 ## Solder paste
 
-* No uncapped vias in pads (except low-power QFNs where some voiding is acceptable)
-* QFN paste prints segmented
-* Small pads 100% size, larger pads reduced to avoid excessive solder volume
+* [ ] No uncapped vias in pads (except low-power QFNs where some voiding is acceptable)
+* [ ] QFN paste prints segmented
+* [ ] Small pads 100% size, larger pads reduced to avoid excessive solder volume
 
 ## Solder mask
 
-* Confirm SMD vs NSMD pad geometry
-* Adequate clearance around pads (typ. 50 um)
+* [ ] Confirm SMD vs NSMD pad geometry
+* [ ] Adequate clearance around pads (typ. 50 um)
 
 ## Silkscreen
 
-* Text size within fab limits
-* Text not overlapping drills or component pads
-* Text removed entirely in, or moved outside of, high component/via density areas
-* Traceability markings (rev, date, name, etc) provided
-* Silkscreen box provided for writing/sticking serial number
-* Text mirrored properly on bottom layer
+* [ ] Text size within fab limits
+* [ ] Text not overlapping drills or component pads
+* [ ] Text removed entirely in, or moved outside of, high component/via density areas
+* [ ] Traceability markings (rev, date, name, etc) provided
+* [ ] Silkscreen box provided for writing/sticking serial number
+* [ ] Text mirrored properly on bottom layer
 
 ## Flex specific
-* Components oriented to reduce bending forces
-* Teardrops on all wire-to-pad connections
+* [ ] Components oriented to reduce bending forces
+* [ ] Teardrops on all wire-to-pad connections
 
 ## CAM production
-* KiCAD specific: rerun DRC and zone fills before exporting CAM files to ensure proper results
-* Export gerber/drill files at the same time to ensure consistency
-* Visually verify final CAM files to ensure no obvious misalignments
+* [ ] KiCAD specific: rerun DRC and zone fills before exporting CAM files to ensure proper results
+* [ ] Export gerber/drill files at the same time to ensure consistency
+* [ ] Visually verify final CAM files to ensure no obvious misalignments

--- a/schematic-checklist.md
+++ b/schematic-checklist.md
@@ -2,93 +2,93 @@
 
 ## General
 
-* CAD ERC 100% clean. If some errors are invalid due to toolchain quirks, each exception must be inspected and signed
+* [ ] CAD ERC 100% clean. If some errors are invalid due to toolchain quirks, each exception must be inspected and signed
 off as invalid.
-* Verify pin numbers of all schematic symbols against datasheet (if not yet board proven).
-* Schematic symbol matches chosen component package
-* Thermal pads are connected to correct power rail (may not always be ground)
-* Debug interfaces are not power gated in sleep mode
+* [ ] Verify pin numbers of all schematic symbols against datasheet (if not yet board proven).
+* [ ] Schematic symbol matches chosen component package
+* [ ] Thermal pads are connected to correct power rail (may not always be ground)
+* [ ] Debug interfaces are not power gated in sleep mode
 
 ## Passive components
-* Power/voltage/tolerance ratings specified as required
-* Ceramic capacitors appropriately de-rated for C/V curve
-* Polarized components specified in schematic if using electrolytic caps etc
+* [ ] Power/voltage/tolerance ratings specified as required
+* [ ] Ceramic capacitors appropriately de-rated for C/V curve
+* [ ] Polarized components specified in schematic if using electrolytic caps etc
 
 ## Power supply
 
 ### System power input
 
-* Fusing and/or reverse voltage protection at system power inlet
-* Check total input capacitance and add inrush limiter if needed
+* [ ] Fusing and/or reverse voltage protection at system power inlet
+* [ ] Check total input capacitance and add inrush limiter if needed
 
 ### Regulators
 
-* Under/overvoltage protection configured correctly if used
-* Verify estimated power usage per rail against regulator rating
-* Current-sense resistors on power rails after regulator output caps, not in switching loop
-* Remote sense used on low voltage or high current rails
-* Linear regulators are stable with selected output cap ESR
-* Confirm power rail sequencing against device datasheets
+* [ ] Under/overvoltage protection configured correctly if used
+* [ ] Verify estimated power usage per rail against regulator rating
+* [ ] Current-sense resistors on power rails after regulator output caps, not in switching loop
+* [ ] Remote sense used on low voltage or high current rails
+* [ ] Linear regulators are stable with selected output cap ESR
+* [ ] Confirm power rail sequencing against device datasheets
 
 ### Decoupling
-* Decoupling present for all ICs
-* Decoupling meets/exceeds vendor recommendations if specified
-* Bulk decoupling present at PSU
+* [ ] Decoupling present for all ICs
+* [ ] Decoupling meets/exceeds vendor recommendations if specified
+* [ ] Bulk decoupling present at PSU
 
 ### General
-* All power inputs fed by correct voltage
-* Check high-power discrete semiconductors and passives to confirm they can handle expected load
-* Analog rails filtered/isolated from digital circuitry as needed
+* [ ] All power inputs fed by correct voltage
+* [ ] Check high-power discrete semiconductors and passives to confirm they can handle expected load
+* [ ] Analog rails filtered/isolated from digital circuitry as needed
 
 ## Signals
 
 ### Digital
 
-* Signals are correct logic level for input pin
-* Pullups on all open-drain outputs
-* Pulldowns on all PECL outputs
-* Termination on all high-speed signals
-* AC coupling caps on gigabit transceivers
-* TX/RX paired correctly for UART, SPI, MGT, etc
-* Differential pair polarity / pairing correct
-* Active high/low enable signal polarity correct
-* I/O banking rules met on FPGAs etc
+* [ ] Signals are correct logic level for input pin
+* [ ] Pullups on all open-drain outputs
+* [ ] Pulldowns on all PECL outputs
+* [ ] Termination on all high-speed signals
+* [ ] AC coupling caps on gigabit transceivers
+* [ ] TX/RX paired correctly for UART, SPI, MGT, etc
+* [ ] Differential pair polarity / pairing correct
+* [ ] Active high/low enable signal polarity correct
+* [ ] I/O banking rules met on FPGAs etc
 
 ### Analog
 
-* RC time constant for attenuators sane given ADC sampling frequency
-* Verify frequency response of RF components across entire operating range. Don't assume a "1-100 MHz" amplifier has the
+* [ ] RC time constant for attenuators sane given ADC sampling frequency
+* [ ] Verify frequency response of RF components across entire operating range. Don't assume a "1-100 MHz" amplifier has the
 same gain across the whole range.
 
 ### Clocks
 
-* All oscillators meet required jitter / frequency tolerance
-* Correct load caps provided for discrete crystals
-* Crystals only used if IC has an integrated crystal driver
-* Banking / clock capable input rules met for clocks going to FPGAs
+* [ ] All oscillators meet required jitter / frequency tolerance
+* [ ] Correct load caps provided for discrete crystals
+* [ ] Crystals only used if IC has an integrated crystal driver
+* [ ] Banking / clock capable input rules met for clocks going to FPGAs
 
 ### Strap/init pins
-* Pullup/pulldowns on all signals that need defined state at boot
-* Strap pins connected to correct rail for desired state
-* JTAG/ICSP connector provided for all programmable devices
-* Config/boot flash provided for all FPGAs or MPUs without internal flash
-* Reference resistors correct value and reference rail
+* [ ] Pullup/pulldowns on all signals that need defined state at boot
+* [ ] Strap pins connected to correct rail for desired state
+* [ ] JTAG/ICSP connector provided for all programmable devices
+* [ ] Config/boot flash provided for all FPGAs or MPUs without internal flash
+* [ ] Reference resistors correct value and reference rail
 
 ### External interface protection
 
-* Power outputs (USB etc) current limited
-* ESD protection on data lines going off board
+* [ ] Power outputs (USB etc) current limited
+* [ ] ESD protection on data lines going off board
 
 ### Debugging / reworkability
 
-* Use 0-ohm resistors vs direct hard-wiring for strap pins when possible
-* Provide multiple ground clips/points for scope probes
-* Dedicated ground in close proximity to analog test points
-* Test points on all power rails
-* Test points on interesting signals which may need probing for bringup/debug
+* [ ] Use 0-ohm resistors vs direct hard-wiring for strap pins when possible
+* [ ] Provide multiple ground clips/points for scope probes
+* [ ] Dedicated ground in close proximity to analog test points
+* [ ] Test points on all power rails
+* [ ] Test points on interesting signals which may need probing for bringup/debug
 
 ## Thermal
 
-* Power estimates for all large / high power ICs
-* Thermal calculations for all large / high power ICs
-* Specify heatsinks as needed
+* [ ] Power estimates for all large / high power ICs
+* [ ] Thermal calculations for all large / high power ICs
+* [ ] Specify heatsinks as needed


### PR DESCRIPTION
Change the bullet points to use Github-Flavored Markdown Checkboxes. A user can then clone the repo directly into their project, and manually check off each entry as needed to keep track of their progress for each PCB!

Updating can either be done [through the text file](https://blog.github.com/2013-01-09-task-lists-in-gfm-issues-pulls-comments/) or by clicking generated checkboxes in a Markdown=>HTML renderer (such as Atom's/Github's).