### PR TITLE
Add errata review to schematic checklist

### DIFF
--- a/schematic-checklist.md
+++ b/schematic-checklist.md
@@ -8,6 +8,7 @@ off as invalid.
 * [ ] Schematic symbol matches chosen component package
 * [ ] Thermal pads are connected to correct power rail (may not always be ground)
 * [ ] Debug interfaces are not power gated in sleep mode
+* [ ] Review errata for each component and adjust schematics accordingly
 
 ## Passive components
 * [ ] Power/voltage/tolerance ratings specified as required


### PR DESCRIPTION
I've been burned before by first-rev ICs shipping without functioning crystal oscillators, incorrect peripheral availability on pins, and strange power supply hacks. All of these problems are quietly mentioned in device errata documentation that is often not referenced in the datasheet. These days, before I ship a board out, I **always** review errata documents for each device, so this item definitely belongs on the checklist!