### PR TITLE
Feedback resistor network for DC-DC converter

### DIFF
--- a/layout-checklist.md
+++ b/layout-checklist.md
@@ -53,9 +53,10 @@
 * [ ] Sufficient width for planes/traces for required current
 
 ## Sensitive analog
-* [ ] Guard ring / EMI cages provided if needed
+* [ ] Guard ring / EMI cages provided if needed ([refer](https://www.st.com/resource/en/application_note/cd00221665-oscillator-design-guide-for-stm8afals-stm32-mcus-and-mpus-stmicroelectronics.pdf) page 46/47).
 * [ ] Physically separated from high current SMPS or other noise sources
 * [ ] Consider microphone effect on MLCCs if near strong sound sources
+* [ ] The track for feedback resistor network used in DC-DC voltage regulator/converter IC to be routed from the last filter capacitor. Avoid routing from the inductor pad which also has the same net name.
 
 ## Mechanical
 * [ ] Confirm all connectors to other systems comply with the appropriate mechanical standard (connector orientation, key position, etc)


### PR DESCRIPTION
The net name for both capacitor and the inductor is same at the output of the DC-DC converter. It is recommended to take the feedback after the filtering of ripples from the capacitors. 